### PR TITLE
feat: added support for notifications via telegram bot

### DIFF
--- a/apps/api/dto/dto.go
+++ b/apps/api/dto/dto.go
@@ -111,7 +111,7 @@ type NotificationData struct {
 
 type NotificationCreateIn struct {
 	Name     string           `json:"name" validate:"required"`
-	Provider string           `json:"provider" validate:"oneof=Discord Slack"`
+	Provider string           `json:"provider" validate:"oneof=Discord Slack Telegram"`
 	Data     NotificationData `json:"data"`
 }
 

--- a/apps/api/utils/alerts/telegram.go
+++ b/apps/api/utils/alerts/telegram.go
@@ -1,0 +1,31 @@
+package alerts
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/chamanbravo/upstat/models"
+)
+
+type TelegramAlertMessage struct {
+	Text      string
+	ParseMode string
+}
+
+func NewTelegramAlert(heartbeat *models.Heartbeat, monitor *models.Monitor) *TelegramAlertMessage {
+	alertText := fmt.Sprintf("✅ Your monitor %v is UP ✅\nMonitor: *%v* | URL: %v\nStatus Code: *%v* | Latency: *%vms*",
+		monitor.Name,
+		monitor.Name,
+		monitor.Url,
+		heartbeat.StatusCode,
+		heartbeat.Latency)
+
+	if heartbeat.Status == "red" {
+		alertText = fmt.Sprintf("❌ Your monitor %v is DOWN ❌\nMonitor: *%v* | URL: %v", monitor.Name, monitor.Name, monitor.Url)
+	}
+
+	return &TelegramAlertMessage{
+		Text:      url.QueryEscape(alertText),
+		ParseMode: "Markdown", // Markdown | HTML, haven't tested with V2 yet
+	}
+}

--- a/apps/api/utils/goroutines.go
+++ b/apps/api/utils/goroutines.go
@@ -110,6 +110,14 @@ func StartGoroutine(monitor *models.Monitor) {
 										log.Printf("Error when trying to convert heartbeat to JSON: %v", err.Error())
 									}
 								}
+
+								if v.Provider == "Telegram" {
+									telegramMessage := alerts.NewTelegramAlert(heartbeat, monitor)
+									_, err := http.Get(fmt.Sprintf("%s&text=%s&parse_mode=%s", v.Data.WebhookUrl, telegramMessage.Text, telegramMessage.ParseMode)) // supports get and post methods, used query params for simplicity of handling user url input
+									if err != nil {
+										log.Printf("Error when trying to send telegram notification: %v", err.Error())
+									}
+								}
 							}
 						} else {
 							log.Printf("Error retrieving notification channels: %v", err)

--- a/apps/web/components/notifications/create-notification-form.tsx
+++ b/apps/web/components/notifications/create-notification-form.tsx
@@ -173,6 +173,33 @@ export default function CreateNotificationForm({ defaultValues }: Props) {
               )}
             />
           )}
+            {provider === "Telegram" && (
+                <FormField
+                    control={form.control}
+                    name="webhookUrl"
+                    render={({ field }) => (
+                        <FormItem className="space-y-1">
+                            <FormLabel>Webhook URL</FormLabel>
+                            <FormControl>
+                                <Input
+                                    placeholder="https://api.telegram.org/bot{token}/sendMessage?chat_id={id}"
+                                    {...field}
+                                />
+                            </FormControl>
+                            <FormDescription>
+                                <Link
+                                    href="https://core.telegram.org/bots/api#sendmessage"
+                                    target="_blank"
+                                    className="ml-auto cursor-pointer hover:underline"
+                                >
+                                    How to setup your Telegram webhook
+                                </Link>
+                            </FormDescription>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+            )}
 
           <Button type="submit" disabled={loading}>
             {loading ? "Loading..." : "Submit"}

--- a/apps/web/components/notifications/provider-dropdown.tsx
+++ b/apps/web/components/notifications/provider-dropdown.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { CaretSortIcon } from "@radix-ui/react-icons";
 
-const providers = ["Discord", "Slack"];
+const providers = ["Discord", "Slack", "Telegram"];
 
 interface Props {
   provider: string;


### PR DESCRIPTION
Changes made:

1. web
- Added form for telegram notifications settings
- Added telegram as a provider
2. api
- Added func for creating alert message sent by the bot
- Added check on whether notifier provider is set to telegram in order to send a notification

Tested on Localhost:
- Notifications are being received in a specified chat

<img width="316" height="163" alt="Screenshot 2025-11-08 at 04 51 11" src="https://github.com/user-attachments/assets/9645d1c0-a8a4-4987-96c7-5f3dab3358a8" />
